### PR TITLE
Fix incorrect redirect path in README.md

### DIFF
--- a/01-basic-streaming-workflow/02-bring-analytics-closer-to-odb/README.md
+++ b/01-basic-streaming-workflow/02-bring-analytics-closer-to-odb/README.md
@@ -1,14 +1,13 @@
 # Bringing analytics closer to operational databases
 
-Operational databases are critical for business operations, but they are also best suited for simple queries. Running complex queries can hinder critical processes. The solution is offloading. Moving the queries to another platform frees up resources for the operational database. 
+Operational databases are critical for business operations, but they are also best suited for simple queries. Running complex queries can hinder critical processes. The solution is offloading. Moving the queries to another platform frees up resources for the operational database.
 
-RisingWave can easily ingest data from operational databases and perform computation-heavy tasks. Using pre-defined computations provided, RisingWave completes the computation when the data is written rather than at the time of querying. This allows for the reuse of repeated computation between multiple queries. 
+RisingWave can easily ingest data from operational databases and perform computation-heavy tasks. Using pre-defined computations provided, RisingWave completes the computation when the data is written rather than at the time of querying. This allows for the reuse of repeated computation between multiple queries.
 
 The demos included in this directory aim to show how RisingWave can be used in stream processing to bring your analytics closer to your operational database.
 
-1. [Create materialized views to offload predefined analytics](/02-bring-analytics-closer-to-odb/001-create-mv-offload-analytics.md)
+1. [Create materialized views to offload predefined analytics](./001-create-mv-offload-analytics.md)
 
-2. [Query through RisingWave](/02-bring-analytics-closer-to-odb/002-query-through-risingwave.md)
+2. [Query through RisingWave](./002-query-through-risingwave.md)
 
-3. [Query the results from the original database](/02-bring-analytics-closer-to-odb/003-query-from-odb.md)
-
+3. [Query the results from the original database](./003-query-from-odb.md)


### PR DESCRIPTION
This PR fixes incorrect document paths in the README.md file. The following relative paths have been corrected:

1. Fixed path to "Create materialized views to offload predefined analytics" document
2. Fixed path to "Query through RisingWave" document
3. Fixed path to "Query the results from the original database" document

These changes ensure all documentation links work properly and users can navigate through the tutorial steps without encountering broken links.

link: https://github.com/risingwavelabs/awesome-stream-processing/tree/main/01-basic-streaming-workflow/02-bring-analytics-closer-to-odb